### PR TITLE
Fix behavior with CDN (allow `application/octet-stream`)

### DIFF
--- a/mods_manager.py
+++ b/mods_manager.py
@@ -558,7 +558,9 @@ def download_mod(file_path, download_url):
     payload = {'username': glob['username'], 'token': glob['token']}
     r = requests.get('https://mods.factorio.com' + download_url, params=payload, stream=True)
 
-    if r.headers.get('Content-Type') != 'application/zip':
+    # the Factorio mod portal may serve downloads via a CDN, which 
+    # returns 'application/octet-stream' as the Content-Type
+    if r.headers.get('Content-Type') != 'application/zip' and r.headers.get('Content-Type') != 'application/octet-stream':
         print('Error : Response is not a Zip file !')
         print('It might happen because your Username and/or Token are wrong or deactivated.')
         print('Aborting the mission...')


### PR DESCRIPTION
The Factorio Mod Portal now delivers its mod content via a CDN (https://forums.factorio.com/viewtopic.php?f=189&t=101184&p=561020) which appears to serve zip files via `application/octet-stream` instead of `application/zip`. 

This was causing downloads with `factorio-mods-manager` to fail with "Response is not a Zip file !" even though the mods were valid downloads and available.

This PR adds `application/octet-stream` as a valid `Content-Type` to pass this check.